### PR TITLE
Fix test configuration and mocks

### DIFF
--- a/src/test/auth-permissions.test.ts
+++ b/src/test/auth-permissions.test.ts
@@ -14,7 +14,7 @@ vi.mock('@/integrations/supabase/client', () => ({
 }));
 
 describe('Authentication & Permissions', () => {
-  const mockUserId = 'user_123';
+  const mockUserId = 'user_123456';
   const mockUser = {
     id: mockUserId,
     firstName: 'John',
@@ -261,9 +261,6 @@ describe('Authentication & Permissions', () => {
         }
       }).not.toThrow();
       
-      // This should throw because invalidUserId is too short
-// (Lines 265–267 removed as they duplicate an earlier test)
-      
       // Test invalid user ID validation
       const validateUserId = (userId: string) => {
         // Clerk user IDs typically have a specific format
@@ -279,5 +276,6 @@ describe('Authentication & Permissions', () => {
       expect(() => validateUserId('')).toThrow('Invalid user ID');
       expect(() => validateUserId('short')).toThrow('Invalid user ID');
       expect(() => validateUserId(invalidUserId)).toThrow('Invalid user ID');
+    });
   });
 });

--- a/src/test/rls-policies.test.ts
+++ b/src/test/rls-policies.test.ts
@@ -17,11 +17,13 @@ describe('RLS Policies & Database Security', () => {
       insert: vi.fn(() => ({
         select: vi.fn(() => Promise.resolve({ data: null, error: null })),
       })),
-      update: vi.fn(() => ({
-        eq: vi.fn(() => ({
+      update: vi.fn(() => {
+        const updateBuilder: any = {
           select: vi.fn(() => Promise.resolve({ data: null, error: null })),
-        })),
-      })),
+        };
+        updateBuilder.eq = vi.fn().mockReturnValue(updateBuilder);
+        return updateBuilder;
+      }),
       delete: vi.fn(() => ({
         eq: vi.fn(() => Promise.resolve({ data: null, error: null })),
       })),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: './src/test/setup.ts',
     css: true,
+    exclude: ['tests/**', '**/node_modules/**'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- ignore playwright specs and node_modules in Vitest config
- fix auth-permissions tests with valid user ID and proper closure
- allow chainable eq mocks in RLS policies tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad674498e4832e9a2868754a4bccf3